### PR TITLE
Heroku 環境での警告表示に対処

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_WITHOUT: "production"


### PR DESCRIPTION
![2016-10-23 18 17 29](https://cloud.githubusercontent.com/assets/1916541/19625220/8b66ce16-994d-11e6-8f1d-88d015bfc738.png)

---

`.bundle` ディレクトリ、`.bundle/config` ファイルをリポジトリ管理下に置かないよう、Heroku から警告が出ていたので、それに対応します

Ref : [Bundler Configuration | Heroku Dev Center](https://devcenter.heroku.com/articles/bundler-configuration)
